### PR TITLE
Fix lab.type="latex" handling in eaxis

### DIFF
--- a/R/prettylab.R
+++ b/R/prettylab.R
@@ -66,7 +66,7 @@ pretty10exp <- function(x, drop.1 = FALSE, sub10 = FALSE,
 		else if(sub.10 &&  noE[i]    ) mTf[i]
 		else if(drop.1 && mT[i] ==  1) sprintf("$10^{%s}$", eTf[i])
 		else if(drop.1 && mT[i] == -1) sprintf("$-10^{%s}$",eTf[i])
-		else sprintf("$%s \\%s 10^{%s}", mTf[i], lab.sep,   eTf[i])
+		else sprintf("$%s \\%s 10^{%s}$", mTf[i], lab.sep,  eTf[i])
 	ss  ## perhaps unlist(ss) ?
     }
 }
@@ -124,7 +124,10 @@ eaxis <- function(side, at = if(log && getRversion() >= "2.14.0")
 	labels <- if(use.expr) {
             pretty10exp(at, drop.1=drop.1, sub10=sub10,
                         lab.type=lab.type, lab.sep=lab.sep)
-        } else TRUE
+        } else if(lab.type == "latex") {
+            paste("$", at, "$", sep="")
+        }
+        else TRUE
     else if(length(labels) == 1 && is.na(labels)) # no 'plotmath'
 	labels <- TRUE
     axis(side, at = at, labels = labels, las=las, ...)


### PR DESCRIPTION
Dear Martin,
as I prefer using _tikzDevice_ for creating my plots and integrating these into papers instead of producing separate pdf/eps/whatever files, I have come to enjoy the pretty axis tick labels from sfsmisc. Unfortunately, the lab.type="latex" handling is incomplete and only triggered if using log or exponential format. This becomes a problem as soon as Computer Modern is not used as default font, as the font faces will not match anymore. The following plot illustrates the problem:
![old](https://cloud.githubusercontent.com/assets/3380687/9095681/d4a43800-3bb8-11e5-85a1-87f23bece1ac.png)
Notice how the x-axis tick labels stop due to the missing "$" bug in pretty10exp and x and y-axis fonts are inconsistent. I've fixed everything and now get
![new](https://cloud.githubusercontent.com/assets/3380687/9095693/f12e8340-3bb8-11e5-8d4d-661650923ca0.png)

to test, try
```
x = (1:10)*1E10
y = 2:11

library("sfsmisc")
library("tikzDevice")
tikz(file="test.tex", standAlone=TRUE)
plot(x, y, axes=FALSE)
eaxis(1, at=x, lab.type="latex")
eaxis(2, at=y, lab.type="latex")
dev.off()
```
and then add
```
\renewcommand{\familydefault}{\sfdefault}
\usepackage{helvet}
```
to the preamble of **test.tex** to see that all axes tick labels are in latex math if requested by lab.type="latex".